### PR TITLE
Exit codes do not propagate when using hub task

### DIFF
--- a/tasks/hub.js
+++ b/tasks/hub.js
@@ -23,6 +23,7 @@ module.exports = function(grunt) {
     this.files = this.files || helpers.normalizeMultiTaskFiles(this.data, this.target);
 
     var done = this.async();
+    var errorCount = 0;
     var tasks = this.data.tasks || 'default';
     // Get process.argv options without grunt.cli.tasks to pass to child processes
     var cliArgs = grunt.util._.without.apply(null, [[].slice.call(process.argv, 2)].concat(grunt.cli.tasks));
@@ -49,12 +50,18 @@ module.exports = function(grunt) {
           // Run grunt this process uses, append the task to be run and any cli options
           args: grunt.util._.union([process.argv[1]].concat(tasks), cliArgs)
         }, function(err, res, code) {
-          if (code !== 0) { grunt.log.error(res.stderr); }
+          if (code !== 0) {
+            errorCount++;
+            grunt.log.error(res.stderr);
+          }
           grunt.log.writeln(res.stdout).writeln('');
           n();
         });
       }, next);
-    }, done);
+    }, function () {
+        var withoutErrors = (errorCount === 0);
+        done(withoutErrors);
+    });
     
   });
 


### PR DESCRIPTION
Use case: I'm using grunt-hub to run unit tests across multiple grunt.js files. If some tests fail, however, the process still has exit code 0.

before:

```
>> Running [test] on mymodule/node_modules/mysubmodule/grunt.js
>> ✖ 1 of 264 tests failed:
>> 
>>   1) fooBar has correct functionality

Running "simplemocha:all" (simplemocha) task
<WARN> Task "simplemocha:all" failed. Use --force to continue. </WARN>
Aborted due to warnings.

Done, without errors.
```

Checking the exit code confirms the exit code is 0, as if there were no errors:

```
> echo $?
0
```

This causes my CI server to not flag the build as broken.

after my patch:

```
>> Running [test] on mymodule/node_modules/mysubmodule/grunt.js
>> ✖ 1 of 264 tests failed:
>> 
>>   1) fooBar has correct functionality

Running "simplemocha:all" (simplemocha) task
<WARN> Task "simplemocha:all" failed. Use --force to continue. </WARN>
Aborted due to warnings.

<WARN> Task "hub:test" failed. Use --force to continue. </WARN>
Aborted due to warnings.

> echo $?
1
```

I based my patch on how [https://github.com/yaymukund/grunt-simple-mocha/blob/master/tasks/simple-mocha.js](grunt-simple-mocha) bubbles the errors.
