### PR TITLE
Cleaner Output

### DIFF
--- a/tasks/hub.js
+++ b/tasks/hub.js
@@ -27,8 +27,12 @@ module.exports = function(grunt) {
 
     var lastGruntFileWritten;
     function write(gruntfile, buf, isError) {
-      var id = gruntfile === lastGruntFileWritten ? '' : ('>> '.cyan + gruntfile + ':\n');
-      grunt.log[(isError) ? 'error' : 'write'](id + buf);
+      if (gruntfile !== lastGruntFileWritten) {
+        grunt.log.writeln('');
+        grunt.log.writeln('');
+        grunt.log.writeln('>> '.cyan + gruntfile + ':\n');
+      }
+      grunt.log[(isError) ? 'error' : 'write'](buf);
       lastGruntFileWritten = gruntfile;
     }
 


### PR DESCRIPTION
Hi,
This pull is my personal preference and it may exist scenarios I haven't thought of. 

I'm using grunt-hub in a client/server senario where I have two grunt-projects in which I want to be able to run grunt tasks at the same time as simple as possible. 

With this code I get the following print.. (my full paths excluded)

```
$ grunt dev
Running "hub:dev" (hub) task
>> Running [dev] on /[...]/server/Gruntfile.js
>> Running [dev] on /[...]/client/Gruntfile.js


>> /[...]/server/Gruntfile.js:

Running "shell:server" (shell) task

Running "watch" task
Waiting...

>> /[...]/client/Gruntfile.js:

Running "connect:client" (connect) task
Started connect web server on localhost:8080.

Running "watch" task
Waiting...

>> /[...]/server/Gruntfile.js:

Server listening at http://0.0.0.0:8081
```

where the code in the master produced a lot of newlines... 
