### PR TITLE
Remove '--gruntfile' and argument from inherited options

### DIFF
--- a/tasks/hub.js
+++ b/tasks/hub.js
@@ -42,7 +42,21 @@ module.exports = function(grunt) {
 
     // our queue for concurrently ran tasks
     var queue = async.queue(function(run, next) {
+      var skipNext = false;
       grunt.log.ok('Running [' + run.tasks + '] on ' + run.gruntfile);
+      if(cliArgs)cliArgs = cliArgs.filter(function (currentValue) {
+        if(skipNext){
+          return (skipNext = false);
+        }
+        var out = /^--gruntfile(=?)/.exec(currentValue);
+        if(out){
+          if(out[1] !== '='){
+            skipNext = true;
+          }
+          return false;
+        }
+        return true;
+      });
       var child = grunt.util.spawn({
         // Use grunt to run the tasks
         grunt: true,


### PR DESCRIPTION
Command line args are passed forward to the child grunt processes - however if the parent gruntfile is explicitly set by the --gruntfile option on the command line, the child grunt process seems to use the first gruntfile specified - in this case the parent gruntfile.

See [this gist](https://gist.github.com/benwhite-ext-nokia/273286a2f03a94ab89a1) for an example - (subdir_Gruntfile.js needs moving to subdir/Gruntfile.js relative to the other parts)

Running the following from the root results in 'Lookout, a badger!' rather than 'Hello world' as expected:

```
grunt --gruntfile /full/path/to/root/Gruntfile.js test-subdir
```

The attached commit resolves this.
